### PR TITLE
added custom versions of postfix and prefix

### DIFF
--- a/src/chomp/pratt.gleam
+++ b/src/chomp/pratt.gleam
@@ -85,11 +85,19 @@ pub fn prefix(
   operator: Parser(x, e, tok, ctx),
   apply: fn(a) -> a,
 ) -> fn(Config(a, e, tok, ctx)) -> Parser(a, e, tok, ctx) {
+  prefix_custom(precedence, operator, fn(a, _) { apply(a) })
+}
+
+pub fn prefix_custom(
+  precedence: Int,
+  operator: Parser(x, e, tok, ctx),
+  apply: fn(a, x) -> a,
+) -> fn(Config(a, e, tok, ctx)) -> Parser(a, e, tok, ctx) {
   fn(config) {
-    use _ <- chomp.do(operator)
+    use op <- chomp.do(operator)
     use subexpr <- chomp.do(sub_expression(config, precedence))
 
-    chomp.return(apply(subexpr))
+    chomp.return(apply(subexpr, op))
   }
 }
 
@@ -114,10 +122,18 @@ pub fn postfix(
   operator: Parser(x, e, tok, ctx),
   apply: fn(a) -> a,
 ) -> Operator(a, e, tok, ctx) {
+  postfix_custom(precedence, operator, fn(a, _) { apply(a) })
+}
+
+pub fn postfix_custom(
+  precedence: Int,
+  operator: Parser(x, e, tok, ctx),
+  apply: fn(a, x) -> a,
+) -> Operator(a, e, tok, ctx) {
   use _ <- Operator
   #(precedence, fn(lhs) {
-    use _ <- chomp.do(operator)
-    chomp.return(apply(lhs))
+    use op <- chomp.do(operator)
+    chomp.return(apply(lhs, op))
   })
 }
 


### PR DESCRIPTION
This PR introduces 4 new functions: `postfix_custom`, `prefix_custom`, `infix_custom` and `operator_custom`. They are very similar to the regular operator functions, but their `apply` parameter has been modified to also take in the output of the `operator` parser.

This allows for more complex operators to be made, more simply, such as function calls (`foo(a, b)`), member access syntax (`a.b.c`), and more.

The names are pretty bad, so feel free to bikeshed and change as you like.

notes:
- the `infix_custom` function is a renamed version of `make_infix`, which takes a `Precedence` type instead of an `Int` tuple (better for a public API, in my opinion). `infix_right` and `infix_left` still only take an `Int` to preserve backwards compatibility.
- `operator_custom` is just a wrapper around the `Operator` constructor